### PR TITLE
Adds API and js for rspec testing

### DIFF
--- a/bin/puppet-validator
+++ b/bin/puppet-validator
@@ -12,6 +12,7 @@ options = {
   :root           => gemroot,
   :csrf           => false,
   :graph          => false,
+  :spec           => '/var/puppet-validator/spec'
 }
 logfile  = $stderr
 loglevel = Logger::WARN
@@ -45,6 +46,10 @@ optparse = OptionParser.new { |opts|
 
     opts.on("-t THEMEDIR", "--theme THEMEDIR", "Path to the theme directory.") do |arg|
         options[:root] = arg
+    end
+
+    opts.on("-s SPECDIR", "--spec SPECDIR", "Path to the directory where spec tests are located.") do |arg|
+        options[:spec] = arg
     end
 
     opts.on("-x", "--csrf", "Protect from cross site request forgery. Requires code to be submitted for validation via the webpage.") do

--- a/lib/puppet-validator.rb
+++ b/lib/puppet-validator.rb
@@ -9,11 +9,12 @@ require 'graphviz'
 require 'nokogiri'
 require 'cgi'
 
-# something like 3,000 lines of code
-MAXSIZE = 100000
-CONTEXT = 3
+MAXSIZE = 100000  # something like 3,000 lines of code
+CONTEXT = 3       # how many lines of code around an error should we highlight?
 
 class PuppetValidator < Sinatra::Base
+  require 'puppet-validator/validators'
+
   set :logging, true
   set :strict, true
 
@@ -129,6 +130,24 @@ class PuppetValidator < Sinatra::Base
 
     erb :result
   end
+
+  #################### API endpoints ####################
+
+  post '/api/v0/validate/rspec' do
+    rspec = PuppetValidator::Validators::Rspec.new(settings.spec)
+    rspec.validate(params['code'], params['spec']).to_json
+  end
+
+#   post '/api/v0/validate/syntax' do
+#   end
+#
+#   post '/api/v0/validate/relationships' do
+#   end
+#
+#   post '/api/v0/validate/lint' do
+#   end
+
+  #######################################################
 
   not_found do
     halt 404, "You shall not pass! (page not found)\n"

--- a/lib/puppet-validator/validators.rb
+++ b/lib/puppet-validator/validators.rb
@@ -1,0 +1,3 @@
+class PuppetValidator::Validators
+  require 'puppet-validator/validators/rspec'
+end

--- a/lib/puppet-validator/validators/rspec.rb
+++ b/lib/puppet-validator/validators/rspec.rb
@@ -1,0 +1,84 @@
+class PuppetValidator::Validators::Rspec
+
+  def initialize(spec)
+    @spec_dir = spec
+  end
+
+  def validate(str, spec)
+    # rspec defines a crapton of global information and doesn't clean up well
+    # between runs. This means that there are global objects that leak and chew
+    # up memory. To counter that, we fork a process to run the spec test.
+    reader, writer = IO.pipe
+    output = nil
+
+    if fork
+      writer.close
+      output = parse_output(reader.read)
+      reader.close
+      Process.wait
+    else
+      reader.close
+      run_rspec("#{@spec_dir}/#{spec}.rb", str, writer)
+      writer.close
+      # if we fire any at_exit hooks, Sinatra has a kitten
+      exit!
+    end
+
+    output
+  end
+
+private
+  def run_rspec(spec_path, str, writer)
+    require 'rspec/core'
+
+    # rspec needs an IO object to write to. We just want it as a string...
+    data = StringIO.new
+    RSpec::configure do |c|
+      c.output_stream = data
+      c.formatter     = 'json'
+    end
+
+    # require *after* setting the output stream or it screams at us
+    # String input depends on https://github.com/rodjek/rspec-puppet/pull/619
+    require 'rspec-puppet'
+    RSpec::configure do |c|
+      c.string        = str
+    end
+
+    begin
+      RSpec::Core::Runner.run([spec_path])
+      writer.write(data.string)
+    rescue StandardError, LoadError => e
+      writer.write({
+        'examples' => [
+          {
+            'status'      => 'failed',
+            'description' => "Error running spec test: #{e.message}",
+          }
+        ]}.to_json)
+    end
+  end
+
+  def parse_output(data)
+    begin
+      result = JSON.parse(data)
+      errors = result['examples']
+                 .select  {|example| example['status'] == 'failed' }
+                 .collect {|example| example['description']        }
+
+      output = {
+        'success' => errors.empty?,
+        'errors'  => errors,
+      }
+    rescue => e
+      output = {
+        'success' => false,
+        'errors' => ["Unknown validator error: #{e.message}"],
+      }
+      puts e.backtrace
+    end
+
+    output
+  end
+
+end

--- a/lib/puppet-validator/validators/rspec.rb
+++ b/lib/puppet-validator/validators/rspec.rb
@@ -46,6 +46,8 @@ private
     end
 
     begin
+      raise(Errno::ENOENT, "Spec path #{spec_path} does not exist") unless File.file? spec_path
+
       RSpec::Core::Runner.run([spec_path])
       writer.write(data.string)
     rescue StandardError, LoadError => e

--- a/public/styles.css
+++ b/public/styles.css
@@ -55,13 +55,25 @@ div.line-highlight.with-tooltip {
     border: 1px solid #ccc;
     border-radius: 3px;
   }
-  textarea.validated,
   .results.success {
     background-color: #61ff6e;
   }
-  textarea.failed,
   .results.fail {
     background-color: #ffb6b6;
+  }
+
+  form.validator {
+    padding: 1em;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+  }
+  form.validated {
+    background-color: #61ff6e;
+    border: 1px solid #17a423;
+  }
+  form.failed {
+    background-color: #ffb6b6;
+    border: 1px solid #981818;
   }
 
   .results p {

--- a/public/styles.css
+++ b/public/styles.css
@@ -55,9 +55,11 @@ div.line-highlight.with-tooltip {
     border: 1px solid #ccc;
     border-radius: 3px;
   }
+  textarea.validated,
   .results.success {
     background-color: #61ff6e;
   }
+  textarea.failed,
   .results.fail {
     background-color: #ffb6b6;
   }

--- a/public/validation.js
+++ b/public/validation.js
@@ -1,0 +1,78 @@
+(function ( $ ) {
+    $.fn.RspecValidator = function(options) {
+      var settings = $.extend({
+         label: "Validate",
+          spec: null,
+          cols: 65,
+          rows: 25,
+        server: "",
+      }, options );
+
+      return this.each(function() {
+        var element = $(this);
+        var server  = settings.server + "/api/v0/validate/rspec"
+        if(element.attr('data-spec')) {
+          settings.spec = element.attr('data-spec')
+
+        }
+
+        if (settings.spec == null) {
+          console.log("[FATAL] RspecValidator: spec is a required parameter.")
+          return;
+        }
+
+        var form    = $("<form>", {
+                         "action": server,
+                         "method": "post",
+                        });
+        var editor  = $("<textarea>", {
+                           "name": "code",
+                           "cols": settings.cols,
+                           "rows": settings.rows,
+                          "class": "validator editor",
+                        });
+        var spec    = $("<input>", {
+                           "name": "spec",
+                           "type": "hidden",
+                          "value": settings.spec,
+                        });
+        var submit  = $("<input>", {
+                           "name": "submit",
+                           "type": "submit",
+                          "value": settings.label,
+                        });
+
+        submit.on('click', function(event){
+          event.preventDefault();
+
+          var editor = $(this).siblings('textarea')
+          var code   = editor.val();
+
+          $.post(server, {code: code, spec: settings.spec}, function(data) {
+            console.log(data);
+            var results = jQuery.parseJSON(data);
+            if(results.success) {
+              editor.addClass('validated');
+              editor.removeClass('failed');
+              alert('yay!');
+            }
+            else {
+              editor.addClass('failed');
+              editor.removeClass('validated');
+              alert("Failures:\n" + results.errors.join("\n"));
+            }
+          }).fail(function(jqXHR) {
+            alert("Unknown API error:\n" + jqXHR.responseText);
+          });
+        });
+
+        form.append(editor);
+        form.append(spec);
+        form.append(submit);
+        element.replaceWith(form)
+
+        return this;
+      });
+    };
+
+}(jQuery));


### PR DESCRIPTION
This is the backend only. No frontend is currently exposed.

Setup:
* On the server, add rspec-puppet tests to `/var/puppet-validator/spec`
* Declare examples as type `:string`

On the frontend:
* Include the js: `<script src="validation.js"></script>`
* Invoke the handler: `$('.validate').RspecValidator();`
* Include tests to be rendered: `<div class="validate" data-spec="facts"></div>`
    * The `data-spec` property should be set to the name of a spec test.
    * Do not include the `.rb. extension.

To use CodeMirror integration, the frontend just needs to declare the js/css like so:

```html
<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.31.0/codemirror.css">
<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.31.0/codemirror.js"></script>
<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.31.0/mode/puppet/puppet.js"></script>
```