### PR TITLE
(maint) Turns this into a proper component module

### DIFF
--- a/pltraining-puppet_validator/examples/init.pp
+++ b/pltraining-puppet_validator/examples/init.pp
@@ -1,3 +1,27 @@
+$vhostname = $::fqdn,
+$port      = '80',
+$path      = '/var/www/puppet-validator'
+
+include epel
+
+class { 'apache':
+  default_vhost => false,
+  subscribe     => Class['puppet-validator'],
+}
+
+class { 'apache::mod::passenger':
+  passenger_high_performance => 'off',
+}
+
+apache::vhost { $vhostname:
+  port           => $port,
+  docroot        => "${path}/public",
+  manage_docroot => false,
+  priority       => '25',
+  passenger_ruby => '/usr/bin/ruby',
+  options        => ['-MultiViews']
+}
+
 class { 'puppet_validator':
-  versions => ['2.7.4', '3.6.2', '3.8.5' ],
+  versions => ['5.3.3', '4.9.0', '2.7.4', '3.6.2', '3.8.5'],
 }

--- a/pltraining-puppet_validator/manifests/init.pp
+++ b/pltraining-puppet_validator/manifests/init.pp
@@ -1,29 +1,8 @@
 class puppet_validator (
-  $vhostname   = $::fqdn,
-  $port        = '80',
-  $path        = '/var/www/puppet-validator',
-  $versions    = undef,
+  String                  $path     = '/var/www/puppet-validator',
+  Optional[Array[String]] $versions = undef,
 ) {
-  include epel
-
-  class { 'apache':
-    default_vhost => false,
-  }
-
-  class { 'apache::mod::passenger':
-    passenger_high_performance => 'off',
-  }
-
-  apache::vhost { $vhostname:
-    port           => $port,
-    docroot        => "${path}/public",
-    manage_docroot => false,
-    priority       => '25',
-    passenger_ruby => '/usr/bin/ruby',
-    options        => ['-MultiViews']
-  }
-
-  # Since we don't use the default vhost, let's make sure the dir exists
+  # let's make sure the dir exists before we try to fill it with content!
   dirtree { $path:
     ensure  => present,
     parents => true,
@@ -35,15 +14,13 @@ class puppet_validator (
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    notify  => Class['apache'],
   }
 
-  exec { 'puppet-validator init':
-    cwd     => $path,
-    creates => "${path}/config.ru",
-    path    => '/bin:/usr/bin/:/usr/local/bin',
-    notify  => Class['apache'],
-    require => Package['puppet-validator'],
+  file { '/var/log/puppet-validator':
+    ensure => file,
+    owner  => 'nobody',
+    group  => 'nobody',
+    mode   => '0644',
   }
 
   package { 'graphviz':
@@ -53,15 +30,13 @@ class puppet_validator (
   package { 'puppet-validator':
     ensure   => present,
     provider => gem,
-    before   => Class['apache'],
   }
 
-  file { '/var/log/puppet-validator':
-    ensure => file,
-    owner  => 'nobody',
-    group  => 'nobody',
-    mode   => '0644',
-    notify => Class['apache'],
+  exec { 'puppet-validator init':
+    cwd     => $path,
+    creates => "${path}/config.ru",
+    path    => '/bin:/usr/bin/:/usr/local/bin',
+    require => Package['puppet-validator'],
   }
 
   # The bindir is to avoid binary collisions with PE. This must be installed


### PR DESCRIPTION
Instead of trying to manage the full stack with apache and all, this is
just a component module like it should be. Since we don't need the janky
multiple RVM environments and the weird symlinks anymore, there's no
need to force the end-to-end config. Instead, users should manage with a
profile.