### PR TITLE
(maint) Use spaces to indent in the code editor

### DIFF
--- a/public/scripts.js
+++ b/public/scripts.js
@@ -72,6 +72,14 @@ $( document ).ready(function() {
                 mode: 'puppet',
     });
 
+    // indent with spaces to match style guide
+    editor.setOption("extraKeys", {
+      Tab: function(cm) {
+        var spaces = Array(cm.getOption("indentUnit") + 1).join(" ");
+        cm.replaceSelection(spaces);
+      }
+    });
+
     $("input#validate").on('click', function(event){
       event.preventDefault();
 


### PR DESCRIPTION
This matches our style guide. Otherwise, puppet-lint will scream at
users. (As I get the frontend ported to use the API, the two js scripts
will converge and then merge.)