### PR TITLE
(maint) Adds the ability to load from paste services

### DIFF
--- a/lib/puppet-validator.rb
+++ b/lib/puppet-validator.rb
@@ -100,6 +100,10 @@ class PuppetValidator < Sinatra::Base
     erb :index
   end
 
+  get '/referer' do
+    redirect "/load/#{request.referer}"
+  end
+
   # The all-in-one blob that renders via an erb page
   post '/validate' do
     logger.info "Validating code from #{request.ip}."

--- a/lib/puppet-validator.rb
+++ b/lib/puppet-validator.rb
@@ -83,10 +83,11 @@ class PuppetValidator < Sinatra::Base
 
     case uri.host
     when 'gist.github.com'
-      code = open("#{uri}/raw").read
+      code = open("#{uri}/raw").read rescue nil
     when 'pastebin.com', 'hastebin.com'
-      code = open("#{uri.scheme}://#{uri.host}/raw#{uri.path}").read
+      code = open("#{uri.scheme}://#{uri.host}/raw#{uri.path}").read rescue nil
     else
+      code = nil
       logger.info "Unrecognized paste service: #{uri}"
     end
 

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -8,6 +8,11 @@ function toggleMenu() {
   $('#checks-menu').slideToggle();
 }
 
+function loadPaste() {
+  var location = $('#location').val();
+  window.location = "/load/"+location;
+}
+
 function gist() {
   var code = $('#code').val();
   if (typeof(code) == 'string' && $.trim(code).length != 0) {
@@ -173,6 +178,16 @@ function puppet_validator(cm, updateLinting, options) {
 $( document ).ready(function() {
   toggleChecks();
   $('#checks-menu').hide();
+
+  $("input#load").on('click', function(event){
+    event.preventDefault();
+    loadPaste();
+  });
+
+  $("input#relationships").on('click', function(event){
+    event.preventDefault();
+    showRelationships();
+  });
 
   // don't fail if the theme doesn't load codemirror
   if(typeof CodeMirror != 'undefined') {

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -17,7 +17,7 @@ function gist() {
   var code = $('#code').val();
   if (typeof(code) == 'string' && $.trim(code).length != 0) {
     var data = {
-      "description": "Validated by " + window.location.href,
+      "description": "Validated by " + window.location.origin + '/referer',
       "public": true,
       "files": {
         "init.pp": {

--- a/public/styles.css
+++ b/public/styles.css
@@ -24,6 +24,9 @@ pre#highlighted {
     margin-right: 0.5em;
   }
 
+#location {
+  width: 60%;
+}
 
 .results,
 .warning {

--- a/views/index.erb
+++ b/views/index.erb
@@ -4,8 +4,8 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.31.0/codemirror.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.31.0/addon/lint/lint.css">
   <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.css">
-  <link rel="stylesheet" href="font-awesome-4.7.0/css/font-awesome.min.css">
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="/font-awesome-4.7.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="/styles.css">
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.min.js"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
@@ -13,7 +13,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.31.0/mode/puppet/puppet.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.31.0/addon/lint/lint.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.31.0/addon/selection/active-line.js"></script>
-  <script src="scripts.js"></script>
+  <script src="/scripts.js"></script>
 </head>
 <body>
   <a href="https://github.com/puppetlabs/puppet-validator"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
@@ -22,15 +22,18 @@
 
   <fieldset id="results" class="results hidden">
     <legend>Validated for Puppet version <span id="version"></span></legend>
-    <img id="share" class="share_icon" title="Gist this validated code..." src="gist.png" onclick="gist();" />
+    <img id="share" class="share_icon" title="Gist this validated code..." src="/gist.png" onclick="gist();" />
     <i class="fa fa-spinner fa-pulse fa-2x" aria-hidden="true" id="spinner"></i>
     <p id="message"></p>
   </fieldset>
 
   <form action="/validate" method="post">
     <% if settings.csrf %><input name="_csrf", type="hidden" value="<%= session[:csrf] %>" /><% end %>
+    <div class="row">
+      <label>Validate a URL:</label><input type="text" name="location" id="location" value="<%= @location %>"><input type="submit" value="Load" id="load" name="load" />
+    </div>
     <div class="entry">
-      <textarea name="code" id="code" cols="65" rows="25"></textarea>
+      <textarea name="code" id="code" cols="65" rows="25"><%= @code %></textarea>
       <div class="row">
         <input type="submit" value="Validate" id="validate">
       </div>
@@ -43,7 +46,7 @@
         </select>
         <label><input type="checkbox" name="lint" id="lint" checked="checked" onchange="toggleChecks();">Include <code>puppet-lint</code> style checks.</label>
         <a id="customize" class="button" href="javascript:toggleMenu();">customize &#9662;</a>
-        <% if settings.graph %><input type="button" name="relationships" id="relationships" value="Show relationships" onclick="showRelationships();"><% end %>
+        <% if settings.graph %><input type="submit" name="relationships" id="relationships" value="Show relationships" /><% end %>
       </div>
       <fieldset id="checks-menu" class="menu">
         <legend>Enabled Lint Checks</legend>


### PR DESCRIPTION
Adds a text input for users to load code to validate from a paste
service. This just redirects to a GET request (which makes it linkable)
that loads (and sanitizes) code from that URL ready to validate.

Example URL: https://54.186.28.212/load/https://gist.github.com/binford2k/53ce944e73b2e633c1148a77ff6c3e60

Also adds the ability to check the referer, so that posted gists can validate themselves.

See https://gist.github.com/anonymous/c14c85ee9c1577caa43c2253e37302fa

Fixes #7