### PR TITLE
(maint) Make errors take visual precedence.

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -125,11 +125,11 @@ div.row {
   text-align: center;
 }
 
-.CodeMirror-line.CodeMirror-lint-mark-error {
-  background-color: #ffefed;
-}
 .CodeMirror-line.CodeMirror-lint-mark-warning {
   background-color: #fff9d2;
+}
+.CodeMirror-line.CodeMirror-lint-mark-error {
+  background-color: #ffefed;
 }
 
 input#validate,


### PR DESCRIPTION
When a line is flagged as both an error and a warning, this will ensure
that the red background of an error is what is displayed.