### PR TITLE
(maint) This ensures that errors don't appear offscreen

### DIFF
--- a/lib/puppet-validator.rb
+++ b/lib/puppet-validator.rb
@@ -248,10 +248,10 @@ class PuppetValidator < Sinatra::Base
       # initial highlighting for the potential syntax error
       if result[:line]
         line       = result[:line]
-        start      = [line - CONTEXT, 1].max
+        start      = [line - CONTEXT, 0].max
 
         result[:messages] << {
-            :from   => [line - CONTEXT, 0],
+            :from   => [start, 0],
               :to   => [line - 1, result[:column]],
           :message  => result[:message],
           :severity => 'error',

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -149,7 +149,9 @@ function puppet_validator(cm, updateLinting, options) {
       $('#share').hide();
 
       if('line' in results) {
-        editor.scrollIntoView(results['line'] - 3, results['line'] + 3);
+        var min = Math.max(results['line'] - 3, 0);
+        var max = Math.min(results['line'] + 3, editor.lineCount());
+        editor.scrollIntoView(min, max);
       }
     }
 


### PR DESCRIPTION
If you try to scroll offscreen or display a highlighted message
offscreen (which happens when we try to display context), then the
editor just crashes and you often have to reload. This prevents that.